### PR TITLE
Implement namespace code running

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ func main() {
 	params["userid"] = generateString()
 
 	// Construct an instance of the Interpreter object.
-	// Initialize ExperimentSalt and set Inputs to params.
+	// Initialize Salt and set Inputs to params.
 	expt := &goplanout.Interpreter{
-		ExperimentSalt: "global_salt",
+		Salt: "global_salt",
 		Evaluated:      false,
 		Inputs:         params,
 		Outputs:        map[string]interface{}{},

--- a/namespace.go
+++ b/namespace.go
@@ -4,34 +4,107 @@ import (
 	"fmt"
 )
 
+type Namespace interface {
+	AddExperiment(name string, code map[string]interface{}, segments int) error
+	RemoveExperiment(name string)
+}
+
 type SimpleNamespace struct {
 	Name               string
 	PrimaryUnit        string
 	NumSegments        int
-	SegmentAllocations []string
-	AvailableSegments  []interface{}
-	CurrentExperiments map[string]PlanOutCode
 	Inputs             map[string]interface{}
+	segmentAllocations map[uint64]string
+	availableSegments  []interface{}
+	currentExperiments map[string]interface{}
 }
 
-func (n *SimpleNamespace) addExperiment(name string, code map[string]interface{}, segments int) error {
-	avail := len(n.AvailableSegments)
+func NewSimpleNamespace(name string, numSegments int, primaryUnit string, inputs map[string]interface{}) SimpleNamespace {
+	avail := make([]interface{}, 0, numSegments)
+	for i := 0; i < numSegments; i++ {
+		avail = append(avail, i)
+	}
+
+	return SimpleNamespace{
+		Name:               name,
+		PrimaryUnit:        primaryUnit,
+		NumSegments:        numSegments,
+		Inputs:             inputs,
+		segmentAllocations: make(map[uint64]string),
+		availableSegments:  avail,
+		currentExperiments: make(map[string]interface{}),
+	}
+}
+
+func (n *SimpleNamespace) Run() (map[string]interface{}, bool) {
+	out := make(map[string]interface{})
+	// Is the unit allocated to an experiment ?
+	if name, ok := n.segmentAllocations[n.getSegment()]; ok {
+		interpreter := &Interpreter{
+			Name:      n.Name + "-" + name,
+			Salt:      n.Name + "." + name,
+			Code:      n.currentExperiments[name],
+			Evaluated: false,
+			Inputs:    n.Inputs,
+			Outputs:   out,
+			Overrides: map[string]interface{}{},
+		}
+		return interpreter.Run()
+	}
+
+	return out, true
+}
+
+func (n *SimpleNamespace) AddExperiment(name string, code map[string]interface{}, segments int) error {
+	avail := len(n.availableSegments)
 	if avail < segments {
 		return fmt.Errorf("Not enough segments available %v to add the new experiment %v\n", avail, name)
 	}
 
+	if _, ok := n.currentExperiments[name]; ok {
+		return fmt.Errorf("There is already and experiment called %s\n", name)
+	}
+
+	n.allocateExperiment(name, segments)
+
+	n.currentExperiments[name] = code
+	return nil
+}
+
+func (n *SimpleNamespace) RemoveExperiment(name string) error {
+	_, exists := n.currentExperiments[name]
+	if !exists {
+		return fmt.Errorf("Experiment %v does not exists in the namespace\n", name)
+	}
+
+	segmentsToFree := make([]uint64, 0, n.NumSegments)
+	for i := range n.segmentAllocations {
+		if n.segmentAllocations[i] == name {
+			segmentsToFree = append(segmentsToFree, uint64(i))
+		}
+	}
+
+	for i := range segmentsToFree {
+		n.availableSegments = append(n.availableSegments, segmentsToFree[i])
+	}
+
+	delete(n.currentExperiments, name)
+	return nil
+}
+
+func (n *SimpleNamespace) allocateExperiment(name string, segments int) {
 	// Sample(choices=available_segments, draws=segments, unit=name)
 	expt := &Interpreter{
-		ExperimentSalt: n.Name,
-		Evaluated:      false,
-		Inputs:         n.Inputs,
-		Outputs:        map[string]interface{}{},
-		Overrides:      map[string]interface{}{},
+		Salt:      n.Name,
+		Evaluated: false,
+		Inputs:    n.Inputs,
+		Outputs:   map[string]interface{}{},
+		Overrides: map[string]interface{}{},
 	}
 
 	// Compile Sample operator
 	m := make(map[string]interface{})
-	m["choices"] = n.AvailableSegments
+	m["choices"] = n.availableSegments
 	m["unit"] = name
 	m["salt"] = n.Name
 	m["draws"] = segments
@@ -42,47 +115,20 @@ func (n *SimpleNamespace) addExperiment(name string, code map[string]interface{}
 	// Remove segment from available_segments
 	for i := range shuffle {
 		j := shuffle[i].(int)
-		n.SegmentAllocations[j] = name
-		n.AvailableSegments = removeByValue(n.AvailableSegments, j).([]interface{})
+		n.segmentAllocations[uint64(j)] = name
+		n.availableSegments = removeByValue(n.availableSegments, j).([]interface{})
 	}
-
-	// Update current_experiments
-	n.CurrentExperiments[name] = code
-
-	return nil
-}
-
-func (n *SimpleNamespace) removeExperiment(name string) error {
-	_, exists := n.CurrentExperiments[name]
-	if !exists {
-		return fmt.Errorf("Experiment %v does not exists in the namespace\n", name)
-	}
-
-	segmentsToFree := make([]int, 0, n.NumSegments)
-	for i := range n.SegmentAllocations {
-		if n.SegmentAllocations[i] == name {
-			segmentsToFree = append(segmentsToFree, i)
-		}
-	}
-
-	for i := range segmentsToFree {
-		n.AvailableSegments = append(n.AvailableSegments, segmentsToFree[i])
-	}
-
-	delete(n.CurrentExperiments, name)
-
-	return nil
 }
 
 func (n *SimpleNamespace) getSegment() uint64 {
 	// generate random integer min=0, max=num_segments, unit=primary_unit
 	// RandomInteger(min=0, max=self.num_segments, unit=itemgetter(*self.primary_unit)(self.inputs))
 	expt := &Interpreter{
-		ExperimentSalt: n.Name,
-		Evaluated:      false,
-		Inputs:         n.Inputs,
-		Outputs:        map[string]interface{}{},
-		Overrides:      map[string]interface{}{},
+		Salt:      n.Name,
+		Evaluated: false,
+		Inputs:    n.Inputs,
+		Outputs:   map[string]interface{}{},
+		Overrides: map[string]interface{}{},
 	}
 
 	// Compile RandomInteger operator
@@ -92,6 +138,5 @@ func (n *SimpleNamespace) getSegment() uint64 {
 	m["max"] = n.NumSegments
 	m["unit"] = n.Inputs[n.PrimaryUnit]
 	s := &randomInteger{}
-	randInt := s.execute(m, expt).(uint64)
-	return randInt
+	return s.execute(m, expt).(uint64)
 }

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -17,36 +17,28 @@
 package goplanout
 
 import (
-	"fmt"
 	"testing"
 )
 
 func TestSimpleNamespace(t *testing.T) {
 	js1 := readTest("test/simple_ops.json")
 	js2 := readTest("test/random_ops.json")
-
-	segments := make([]string, 100)
-	avail := make([]interface{}, 0, 100)
-	for i := 0; i < 100; i++ {
-		avail = append(avail, i)
-	}
+	js3 := readTest("test/simple.json")
 
 	inputs := make(map[string]interface{})
-	inputs["userid"] = generateString()
+	inputs["userid"] = "test-id"
 
-	n := &SimpleNamespace{
-		Name:               "simple_namespace",
-		NumSegments:        100,
-		PrimaryUnit:        "userid",
-		SegmentAllocations: segments,
-		AvailableSegments:  avail,
-		CurrentExperiments: map[string]PlanOutCode{},
-		Inputs:             inputs,
+	n := NewSimpleNamespace("simple_namespace", 100, "userid", inputs)
+	n.AddExperiment("simple ops", js1, 10)
+	n.AddExperiment("random ops", js2, 10)
+	n.AddExperiment("simple", js3, 80)
+
+	if n.getSegment() != 79 {
+		t.Errorf("Incorrect allocation for test-id")
 	}
 
-	n.addExperiment("simple ops", js1, 50)
-	n.addExperiment("random ops", js2, 50)
-	// n.removeExperiment("simple ops")
+	if out, ok := n.Run(); !ok || out["output"] != "test" {
+		t.Errorf("Namespace run was not successful out:[%s]", out)
+	}
 
-	fmt.Printf("Random segment alloc: %v\n", n.getSegment())
 }

--- a/random_ops_test.go
+++ b/random_ops_test.go
@@ -38,13 +38,15 @@ func TestRandomOps(t *testing.T) {
 		userids = append(userids, userid)
 
 		expt := &Interpreter{
-			ExperimentSalt: "global_salt",
-			Evaluated:      false,
-			Inputs:         params,
-			Outputs:        map[string]interface{}{},
-			Overrides:      map[string]interface{}{},
+			Salt:      "global_salt",
+			Evaluated: false,
+			Inputs:    params,
+			Outputs:   map[string]interface{}{},
+			Overrides: map[string]interface{}{},
+			Code:      js,
 		}
-		output, ok := expt.Run(js)
+
+		output, ok := expt.Run()
 		if !ok {
 			t.Errorf("Error running experiment 'test/random_ops.json'\n")
 			return

--- a/simple_ops_test.go
+++ b/simple_ops_test.go
@@ -43,14 +43,15 @@ func TestSimpleOps(t *testing.T) {
 	params["struct"] = data
 
 	expt := &Interpreter{
-		ExperimentSalt: "global_salt",
-		Evaluated:      false,
-		Inputs:         params,
-		Outputs:        map[string]interface{}{},
-		Overrides:      map[string]interface{}{},
+		Salt:      "global_salt",
+		Evaluated: false,
+		Inputs:    params,
+		Outputs:   map[string]interface{}{},
+		Overrides: map[string]interface{}{},
+		Code:      js,
 	}
 
-	output, ok := expt.Run(js)
+	output, ok := expt.Run()
 	if !ok {
 		t.Errorf("Error running experiment 'test/simple_ops.json'\n")
 		return

--- a/test/simple.json
+++ b/test/simple.json
@@ -1,0 +1,10 @@
+{
+  "op": "seq",
+  "seq": [
+    {
+      "op": "set",
+      "var": "output",
+      "value": "test"
+    }
+  ]
+}

--- a/test/simple.planout
+++ b/test/simple.planout
@@ -1,0 +1,1 @@
+output = "test";


### PR DESCRIPTION
Thoughts ? 

@tsujeeth I think this is what we need to make namespaces work.

I hid away most of SimpleNamespace as there is IMHO a bunch of stuff there that is specific to that implementation.

I made a generic Run() interface that I think should cover both Namespace and Interpreter.

I am with @eytan, we should sort out the m map, Salt and Outputs a bit, its a tad confused what belongs to what and what the caller should provide and what the callee provides.

@eytan from what I can ascertain namespace is bound to a primary unit (e.g. userid) with each experiment getting allocated to buckets in that namespace. If two experiments get allocated to the same segment, the first one in wins? This would mean that for the primary unit, per namespace, one experiment runs for an allocation ?