### PR TITLE
Fix for index operations returning a nil value

### DIFF
--- a/index_op_test.go
+++ b/index_op_test.go
@@ -6,6 +6,27 @@ import (
 	"encoding/json"
 )
 
+func getInterpreter(filename string) (*Interpreter, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var js map[string]interface{}
+	err = json.Unmarshal(data, &js)
+	if (err != nil) {
+		return nil, err
+	}
+
+	return &Interpreter{
+		Name: "the name",
+		Salt: "the salt",
+		Evaluated: false,
+		Inputs: make(map[string]interface{}),
+		Outputs: make(map[string]interface{}),
+		Code: js,
+	}, nil
+}
+
 type Inner struct {
 	Value string
 }
@@ -19,32 +40,17 @@ type NestedStruct struct {
 }
 
 func TestNestedIndex(t *testing.T) {
-	data, err := ioutil.ReadFile("test/nested_index.json")
+	exp, err := getInterpreter("test/nested_index.json")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var js map[string]interface{}
-	err = json.Unmarshal(data, &js)
-	if (err != nil) {
-		t.Fatal(err)
-	}
 
-	inputs := make(map[string]interface{})
-	inputs["s"] = &NestedStruct{
+	exp.Inputs["s"] = &NestedStruct{
 		Outer: &Outer{
 			Inner: &Inner{
 				Value: "foo",
 			},
 		},
-	}
-
-	exp := &Interpreter{
-		Name: "nested_test",
-		Salt: "salt123",
-		Evaluated: false,
-		Inputs: inputs,
-		Outputs: make(map[string]interface{}),
-		Code: js,
 	}
 
 	if _, ok := exp.Run(); !ok {
@@ -61,28 +67,14 @@ type StructWithArray struct {
 }
 
 func TestArrayInStruct(t *testing.T) {
-	data, err := ioutil.ReadFile("test/array_field_test.json")
+	exp, err := getInterpreter("test/array_field_test.json")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var js map[string]interface{}
-	err = json.Unmarshal(data, &js)
-	if (err != nil) {
-		t.Fatal(err)
-	}
 
-	inputs := make(map[string]interface{})
-	i := 123
-	inputs["s"] = &StructWithArray{
+	i := int(123)
+	exp.Inputs["s"] = &StructWithArray{
 		Array: []*int{&i},
-	}
-
-	exp := &Interpreter{
-		Name: "test_array_field",
-		Salt: "blasdfalks",
-		Inputs: inputs,
-		Outputs: make(map[string]interface{}),
-		Code: js,
 	}
 
 	if _, ok := exp.Run(); !ok {
@@ -99,29 +91,15 @@ type StructWithMap struct {
 }
 
 func TestMapField(t *testing.T) {
-	data, err := ioutil.ReadFile("test/map_index_test.json")
+	exp, err := getInterpreter("test/map_index_test.json")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var js map[string]interface{}
-	err = json.Unmarshal(data, &js)
-	if (err != nil) {
-		t.Fatal(err)
-	}
 
-	inputs := make(map[string]interface{})
 	mapField := make(map[string]int64)
 	mapField["key"] = 42
-	inputs["s"] = &StructWithMap{
+	exp.Inputs["s"] = &StructWithMap{
 		Map: mapField,
-	}
-
-	exp := &Interpreter{
-		Name: "test_map_index",
-		Salt: "asdfkhjaslkdfjh",
-		Inputs: inputs,
-		Outputs: make(map[string]interface{}),
-		Code: js,
 	}
 
 	if _, ok := exp.Run(); !ok {
@@ -142,26 +120,12 @@ type StructWithNilField struct {
 }
 
 func TestStructWithNilField(t *testing.T) {
-	data, err := ioutil.ReadFile("test/struct_with_nil_field.json")
+	exp, err := getInterpreter("test/struct_with_nil_field.json")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var js map[string]interface{}
-	err = json.Unmarshal(data, &js)
-	if (err != nil) {
-		t.Fatal(err)
-	}
 
-	inputs := make(map[string]interface{})
-	inputs["struct"] = &StructWithNilField{}
-
-	exp := &Interpreter{
-		Name: "struct with nil field",
-		Salt: "safasdf",
-		Inputs: inputs,
-		Outputs: make(map[string]interface{}),
-		Code: js,
-	}
+	exp.Inputs["struct"] = &StructWithNilField{}
 
 	if _, ok := exp.Run(); !ok {
 		t.Fatal("Experiment run failed")

--- a/index_op_test.go
+++ b/index_op_test.go
@@ -1,9 +1,9 @@
 package planout
 
 import (
-	"testing"
-	"io/ioutil"
 	"encoding/json"
+	"io/ioutil"
+	"testing"
 )
 
 func getInterpreter(filename string) (*Interpreter, error) {
@@ -13,17 +13,17 @@ func getInterpreter(filename string) (*Interpreter, error) {
 	}
 	var js map[string]interface{}
 	err = json.Unmarshal(data, &js)
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
 	return &Interpreter{
-		Name: "the name",
-		Salt: "the salt",
+		Name:      "the name",
+		Salt:      "the salt",
 		Evaluated: false,
-		Inputs: make(map[string]interface{}),
-		Outputs: make(map[string]interface{}),
-		Code: js,
+		Inputs:    make(map[string]interface{}),
+		Outputs:   make(map[string]interface{}),
+		Code:      js,
 	}, nil
 }
 
@@ -57,7 +57,7 @@ func TestNestedIndex(t *testing.T) {
 		t.Fatal("Failed to run experiment")
 	}
 
-	if (exp.Outputs["out"] != "foo") {
+	if exp.Outputs["out"] != "foo" {
 		t.Fail()
 	}
 }

--- a/index_op_test.go
+++ b/index_op_test.go
@@ -95,7 +95,7 @@ func TestArrayInStruct(t *testing.T) {
 }
 
 type StructWithMap struct {
-	Map map[string]string
+	Map map[string]int64
 }
 
 func TestMapField(t *testing.T) {
@@ -110,8 +110,8 @@ func TestMapField(t *testing.T) {
 	}
 
 	inputs := make(map[string]interface{})
-	mapField := make(map[string]string)
-	mapField["key"] = "value"
+	mapField := make(map[string]int64)
+	mapField["key"] = 42
 	inputs["s"] = &StructWithMap{
 		Map: mapField,
 	}
@@ -128,7 +128,46 @@ func TestMapField(t *testing.T) {
 		t.Fatal("Experiment run failed")
 	}
 
-	if elem := exp.Outputs["element"]; elem != "value" {
+	if elem := exp.Outputs["element"]; elem != int64(42) {
+		t.Fail()
+	}
+
+	if exp.Outputs["empty"] != nil {
+		t.Fail()
+	}
+}
+
+type StructWithNilField struct {
+	None interface{}
+}
+
+func TestStructWithNilField(t *testing.T) {
+	data, err := ioutil.ReadFile("test/struct_with_nil_field.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var js map[string]interface{}
+	err = json.Unmarshal(data, &js)
+	if (err != nil) {
+		t.Fatal(err)
+	}
+
+	inputs := make(map[string]interface{})
+	inputs["struct"] = &StructWithNilField{}
+
+	exp := &Interpreter{
+		Name: "struct with nil field",
+		Salt: "safasdf",
+		Inputs: inputs,
+		Outputs: make(map[string]interface{}),
+		Code: js,
+	}
+
+	if _, ok := exp.Run(); !ok {
+		t.Fatal("Experiment run failed")
+	}
+
+	if exp.Outputs["nil"] != nil {
 		t.Fail()
 	}
 }

--- a/operators.go
+++ b/operators.go
@@ -213,7 +213,11 @@ func unwrapValue(value reflect.Value) interface{} {
 	case reflect.Bool:
 		return value.Bool()
 	default:
-		return value.Interface()
+		if value.IsValid() {
+			return value.Interface()
+		} else {
+			return nil
+		}
 	}
 }
 

--- a/test/map_index_test.json
+++ b/test/map_index_test.json
@@ -32,6 +32,18 @@
         },
         "index": "key"
       }
+    },
+    {
+      "op": "set",
+      "var": "empty",
+      "value": {
+        "op": "index",
+        "base": {
+          "op": "get",
+          "var": "map"
+        },
+        "index": "not there"
+      }
     }
   ]
 }

--- a/test/struct_with_nil_field.json
+++ b/test/struct_with_nil_field.json
@@ -1,0 +1,12 @@
+{
+  "op": "set",
+  "var": "nil",
+  "value": {
+    "op": "index",
+    "base": {
+      "op": "get",
+      "var": "struct"
+    },
+    "index": "None"
+  }
+}


### PR DESCRIPTION
See commit message for 749972d for more detail.

The gist is that when an index operation (like getting a field from a struct) returns a nil value, previously we would panic. This change makes it return a nil, without panicking.

@tsujeeth 